### PR TITLE
Adding "download_path" to translated payload

### DIFF
--- a/WordPressService/index.js
+++ b/WordPressService/index.js
@@ -83,10 +83,18 @@ let add_count = 0, update_count = 0, delete_count = 0, binary_match_count = 0, s
 
 //Translation Update
 const translationUpdatePayload = [];
-const translationUpdateAddPost = Post => {
+const translationUpdateAddPost = (Post, download_path) => {
     if(Post.translate) {
         //Send pages marked "translate"
-        const translationRow = {id : Post.id, slug : Post.slug, modified : Post.modified};
+        const translationRow = {
+            id : Post.id, 
+            slug : Post.slug, 
+            modified : Post.modified,
+            download_path // sample ... '/master/pages/wordpress-posts/reopening-matrix-data.json'
+        };
+
+//download_path should be testable by adding to...
+//https://raw.githubusercontent.com/cagov/covid19
 
         if(Post.tags.includes(tag_translatepriority)) {
             //priority translation marked
@@ -421,7 +429,7 @@ for(const mergetarget of mergetargets) {
                         
                         shaupdate(sourcefile, mysha, updateResult.content.sha);
                         if(mergetarget===masterbranch) {
-                            translationUpdateAddPost(sourcefile);
+                            translationUpdateAddPost(sourcefile, `/${mergetarget}/${targetfile.path}`);
                         }
                     } else {
                         console.log(`File compare matched: ${sourcefile.filename}`);
@@ -444,7 +452,7 @@ for(const mergetarget of mergetargets) {
                 await branchMerge(body.branch, mergetarget);
                 shaupdate(sourcefile, mysha, addResult.content.sha);
                 if(mergetarget===masterbranch) {
-                    translationUpdateAddPost(sourcefile);
+                    translationUpdateAddPost(sourcefile, `/${mergetarget}/${newFilePath}`);
                 }
             }
         }


### PR DESCRIPTION
See specs...
https://docs.google.com/document/d/1Y74qSIXeK0iW-2354ZhNxcN0VW3j1LfXPZHEYtGRB2A/edit

Adding `download_path` to payload...

**Download_Path** - Path to download the build compatible content.  The content could be in JSON format or have 11ty tags in the header.  The content should use this URL as a root... https://raw.githubusercontent.com/cagov/covid19

New payload sample...
```
{
	"posts":
	[
		{
    		"id": 36,
    		"slug": "education",
    		"modified": "2020-04-27T23:14:07",
		"download_path": "/master/pages/wordpress-posts/education.html",
		"priority": true ---Optional to indicate a priority translation
		}
	]
	,"test": 1    ---Optional to indicate a test request
}

```