### PR TITLE
News Feed - Trimming Zero Width Space from dates

### DIFF
--- a/covid-news-feed/sources/cdph.js
+++ b/covid-news-feed/sources/cdph.js
@@ -43,11 +43,13 @@ function parseItem(news) {
     let delimiter = ', 2020';
     if(desc.indexOf(delimiter) > -1) {
       let pieces = desc.split(delimiter);
-      let parsedDate = new Date(pieces[0].trim()+delimiter)
+      let parsedDate = new Date(pieces[0]
+        .replace(/\u200B/g,'') //also remove char 8203 (Unicode Character 'ZERO WIDTH SPACE' (U+200B).)
+        .trim()+delimiter);
       if(parsedDate && parsedDate.getTime() > 1577865600000 && parsedDate.getTime() < 1609401600000) {
         newsObject.date = parsedDate.toISOString();
       } else {
-        console.log('date fail')
+        console.error('date fail');
       }
       let description = pieces[1].trim();
       if(description.indexOf('-') === 0 || description.indexOf('–') === 0) {


### PR DESCRIPTION
News Feed - Removing ZERO WIDTH SPACE from dates before trimming.  Reduces failed dates.

https://stackoverflow.com/questions/2973698/whats-html-character-code-8203