### PR TITLE
Using the branch reference for updates.

### DIFF
--- a/WordPressService/index.js
+++ b/WordPressService/index.js
@@ -192,6 +192,9 @@ for(const mergetarget of mergetargets) {
                         //Update file
                         const message = gitHubMessage('Update page',targetfile.name);
                         const branch = await branchCreate_WithName(sourcefile.slug, mergetarget);
+
+                        //get the file reference attached to the new branch.
+                        targetfile = await gitHubFileGet(targetfile.path,branch);
                         
                         const updateResult = await gitHubFileUpdate(content,targetfile.url,targetfile.sha,message,branch)
                             .then(r => {


### PR DESCRIPTION
Making sure updates apply to the sha value in the branch created for them.  Should reduce concurrency failures.

Works on...
https://digital-ca-gov.atlassian.net/browse/CCG-839