### PR TITLE
Adding fix for concurrency update errors

### DIFF
--- a/WordPressService/index.js
+++ b/WordPressService/index.js
@@ -183,7 +183,17 @@ module.exports = async function (context, req) {
               if(content!==targetcontent) {
                 //Update file
                 const message = gitHubMessage('Update page',targetfile.name);
-                await gitRepo.writeFile(mergetarget, targetfile.path, content, message, {committer,encode:false});
+                await gitRepo.writeFile(mergetarget, targetfile.path, content, message, {committer,encode:false})
+                  .catch(error => {
+                    switch (error.response.status) {
+                    case 409:
+                      //conflicts could mean that the page was updated by another process.  No need to stop.
+                      console.error('409 conflict skipped');
+                      return null;
+                    default:
+                      throw error;
+                    }
+                  });
 
                 console.log(`UPDATE Success: ${sourcefile.filename}`);
                 update_count++;


### PR DESCRIPTION
When the Wordpress process runs more than once at a time, it's possible for the update process to see conflicts during an update.  The files get updated ok, but the process stops and reports an exception.  The code to look for is 409, and it's worth skipping in this case.