### PR TITLE
Live migration tasks

### DIFF
--- a/PantheonService/index.js
+++ b/PantheonService/index.js
@@ -30,8 +30,9 @@ const forceTranslateSlug = null; //'safer-economy-lang';
 //const masterbranch='synctest3', stagingbranch='synctest3_staging', postTranslationUpdates = false;
 
 // const masterbranch='master', stagingbranch='staging', postTranslationUpdates = true;
-const masterbranch='preproduction', 
-      stagingbranch='staging-pantheon', 
+// was preproduction / staging-pantheon
+const masterbranch='master', 
+      stagingbranch='staging', 
       postTranslationUpdates = false;
 
 const mergetargets = [masterbranch,stagingbranch];

--- a/WordPressService/index.js
+++ b/WordPressService/index.js
@@ -61,6 +61,12 @@ module.exports = async function (context, req) {
 
   try { // The entire module
 
+    // EARLY RETURN - THIS SERVICE IS DISABLED
+    const errorTitle = 'Old WordPressService needlessly invoked (wordpress-integration-api)';
+    await slackBotReportError(slackErrorChannel,errorTitle,e,req);
+    context.done();
+    return;
+
     if(req.method==='GET') {
     //Hitting the service by default will show the index page.
       context.res = {


### PR DESCRIPTION
1.  Points PantheonService to update master / staging branch on Covid19 repo.
2. Disables old WordPressService and outputs a message if it gets called.